### PR TITLE
Add HTMLHint linter and workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run lint

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,11 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "spec-char-escape": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "attr-no-duplication": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Lyly-turman
 Proyecto Lily
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Ejecutar el linter
+
+```bash
+npm run lint
+```
+
+El proyecto incluye un flujo de trabajo de GitHub Actions que ejecuta este
+comando en cada _pull request_.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lyly-turman",
+  "version": "1.0.0",
+  "description": "Proyecto Lily",
+  "main": "index.js",
+  "scripts": {
+    "lint": "htmlhint \"**/*.html\"",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^1.1.4"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize npm project
- add HTMLHint config and lint script
- document linter setup in README
- add GitHub Actions workflow to run the linter

## Testing
- `npm run lint` *(fails: `htmlhint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6fc21070832fbba38e746a7990e7