### PR TITLE
Add linters and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run lint

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,5 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "doctype-first": true
+}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ npx http-server
 
 Then navigate to the displayed local address, typically `http://localhost:8000`.
 
+
+## Development
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Run linters with:
+
+```bash
+npm run lint
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "lyly-turman",
+  "version": "1.0.0",
+  "description": "This project is a simple static site using HTML, Tailwind CSS and vanilla JavaScript. It contains placeholder sections for a hero banner, artists, events, gallery, testimonials and contact information.",
+  "main": "index.js",
+  "scripts": {
+    "lint:html": "htmlhint **/*.html",
+    "lint:css": "stylelint **/*.css",
+    "lint": "npm run lint:html && npm run lint:css",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^0.16.2",
+    "stylelint": "^15.10.2",
+    "stylelint-config-standard": "^34.0.0"
+  }
+}

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: "stylelint-config-standard"
+};


### PR DESCRIPTION
## Summary
- configure HTMLHint
- configure Stylelint
- add npm scripts for linting
- document development steps
- run lint on GitHub Actions

## Testing
- `npm run lint` *(fails: htmlhint not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c710eeb00832f9e8ae2611297ea87